### PR TITLE
update vert.x to 3.8.3 and resolve deprecations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
     <jib-maven-plugin.version>1.8.0</jib-maven-plugin.version>
 
-    <vertx.version>3.7.1</vertx.version>
+    <vertx.version>3.8.5</vertx.version>
     <junit-jupiter.version>5.4.0</junit-jupiter.version>
     <slf4j-api.version>1.7.25</slf4j-api.version>
 

--- a/src/main/java/com/danielprinz/udemy/books/MainVerticle.java
+++ b/src/main/java/com/danielprinz/udemy/books/MainVerticle.java
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
@@ -20,7 +20,7 @@ public class MainVerticle extends AbstractVerticle {
   private InMemoryBookStore store = new InMemoryBookStore();
 
   @Override
-  public void start(Future<Void> startFuture) throws Exception {
+  public void start(Promise<Void> startFuture) throws Exception {
     LOG.debug("starting...");
     Router books = Router.router(vertx);
     books.route().handler(BodyHandler.create());

--- a/src/main/java/com/danielprinz/udemy/books/jdbc/JDBCBookRepository.java
+++ b/src/main/java/com/danielprinz/udemy/books/jdbc/JDBCBookRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.danielprinz.udemy.books.Book;
 
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -25,7 +26,7 @@ public class JDBCBookRepository {
   }
 
   public Future<JsonArray> getAll() {
-    final Future<JsonArray> getAll = Future.future();
+    final Promise<JsonArray> getAll = Promise.promise();
     sql.query("SELECT * FROM books", ar -> {
       if (ar.failed()){
         //Forward error
@@ -38,11 +39,11 @@ public class JDBCBookRepository {
       rows.forEach(result::add);
       getAll.complete(result);
     });
-    return getAll;
+    return getAll.future();
   }
 
   public Future<Void> add(final Book bookToAdd) {
-    final Future<Void> added = Future.future();
+    final Promise<Void> added = Promise.promise();
     final JsonArray params = new JsonArray().add(bookToAdd.getIsbn()).add(bookToAdd.getTitle());
     sql.updateWithParams("INSERT INTO books (isbn, title) VALUES (?, ?)", params, ar -> {
       if (ar.failed()){
@@ -58,11 +59,11 @@ public class JDBCBookRepository {
       //Return success
       added.complete();
     });
-    return added;
+    return added.future();
   }
 
   public Future<String> delete(final String isbn) {
-    final Future<String> deleted = Future.future();
+    final Promise<String> deleted = Promise.promise();
     final JsonArray params = new JsonArray().add(Long.parseLong(isbn));
     sql.updateWithParams("DELETE FROM books where books.isbn = ?", params, ar -> {
       if (ar.failed()){
@@ -78,6 +79,6 @@ public class JDBCBookRepository {
       //Return deleted isbn
       deleted.complete(isbn);
     });
-    return deleted;
+    return deleted.future();
   }
 }

--- a/src/main/java/com/danielprinz/udemy/books/jdbc/JDBCMainVerticle.java
+++ b/src/main/java/com/danielprinz/udemy/books/jdbc/JDBCMainVerticle.java
@@ -9,7 +9,7 @@ import com.danielprinz.udemy.books.InMemoryBookStore;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
@@ -24,7 +24,7 @@ public class JDBCMainVerticle extends AbstractVerticle {
   private JDBCBookRepository bookRepository;
 
   @Override
-  public void start(Future<Void> startFuture) throws Exception {
+  public void start(Promise<Void> start) throws Exception {
     LOG.debug("starting...");
     //Initialize Database Connection
     bookRepository = new JDBCBookRepository(vertx);
@@ -49,10 +49,10 @@ public class JDBCMainVerticle extends AbstractVerticle {
 
     vertx.createHttpServer().requestHandler(books).listen(8888, http -> {
       if (http.succeeded()) {
-        startFuture.complete();
+        start.complete();
         LOG.info("HTTP server started on port 8888");
       } else {
-        startFuture.fail(http.cause());
+        start.fail(http.cause());
       }
     });
   }


### PR DESCRIPTION
This pull requests shows how to update from vert.x 3.7 to vert.x 3.8 and resolve the deprecations. By resolving the deprecations the application will be ready for the next major version 4 of the vert.x framework.